### PR TITLE
Added functionality to export JVM information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.padaiyal.utilities</groupId>
   <artifactId>vaidhiyar</artifactId>
-  <version>2021.02.01</version>
+  <version>2021.02.09</version>
 
   <parent>
     <groupId>org.padaiyal</groupId>
@@ -27,6 +27,7 @@
     <dependency.jProperties.version>2021.01.13</dependency.jProperties.version>
     <dependency.jI18n.version>2021.01.14</dependency.jI18n.version>
     <dependency.mockito.version>3.7.7</dependency.mockito.version>
+    <dependency.gson.version>2.8.5</dependency.gson.version>
   </properties>
 
   <dependencies>
@@ -57,6 +58,11 @@
       <artifactId>mockito-inline</artifactId>
       <version>${dependency.mockito.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${dependency.gson.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/padaiyal/utilities/vaidhiyar/abstractions/ExtendedMemoryUsage.java
+++ b/src/main/java/org/padaiyal/utilities/vaidhiyar/abstractions/ExtendedMemoryUsage.java
@@ -1,10 +1,10 @@
 package org.padaiyal.utilities.vaidhiyar.abstractions;
 
+import com.google.gson.JsonObject;
 import java.lang.management.MemoryUsage;
 
 /**
- * An extension on the MemoryUsage object.
- * https://docs.oracle.com/en/java/javase/14/docs/api/java.management/java/lang/management/
+ * An extension on the MemoryUsage object. https://docs.oracle.com/en/java/javase/14/docs/api/java.management/java/lang/management/
  * GarbageCollectorMXBean.html
  */
 public class ExtendedMemoryUsage extends MemoryUsage {
@@ -75,5 +75,23 @@ public class ExtendedMemoryUsage extends MemoryUsage {
    */
   public double getMemoryUsagePercentage() {
     return memoryUsagePercentage;
+  }
+
+  /**
+   * Gets a JSON representation of an instance of this class.
+   *
+   * @return JSON representation of an instance of this class.
+   */
+  public JsonObject toJsonObject() {
+    JsonObject extendedMemoryUsageJsonObject = new JsonObject();
+    extendedMemoryUsageJsonObject.addProperty("initMemoryInBytes", getInit());
+    extendedMemoryUsageJsonObject.addProperty("usedMemoryInBytes", getUsed());
+    extendedMemoryUsageJsonObject.addProperty("committedMemoryInBytes", getCommitted());
+    extendedMemoryUsageJsonObject.addProperty("maxMemoryInBytes", getMax());
+    extendedMemoryUsageJsonObject.addProperty(
+        "memoryUsagePercentage",
+        getMemoryUsagePercentage()
+    );
+    return extendedMemoryUsageJsonObject;
   }
 }

--- a/src/main/java/org/padaiyal/utilities/vaidhiyar/abstractions/ExtendedThreadInfo.java
+++ b/src/main/java/org/padaiyal/utilities/vaidhiyar/abstractions/ExtendedThreadInfo.java
@@ -1,6 +1,9 @@
 package org.padaiyal.utilities.vaidhiyar.abstractions;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import java.lang.management.ThreadInfo;
+import java.util.Arrays;
 
 /**
  * Abstraction to store the ThreadInfo object along with additional information.
@@ -23,8 +26,8 @@ public class ExtendedThreadInfo {
   /**
    * Constructor used to abstract thread information.
    *
-   * @param threadInfo ThreadInfo object of the thread.
-   * @param cpuUsage CPU usage of the thread.
+   * @param threadInfo             ThreadInfo object of the thread.
+   * @param cpuUsage               CPU usage of the thread.
    * @param memoryAllocatedInBytes Memory allocated by the thread in bytes
    */
   public ExtendedThreadInfo(ThreadInfo threadInfo, double cpuUsage, long memoryAllocatedInBytes) {
@@ -58,5 +61,38 @@ public class ExtendedThreadInfo {
    */
   public long getMemoryAllocatedInBytes() {
     return memoryAllocatedInBytes;
+  }
+
+  /**
+   * Gets a JSON representation of an instance of this class.
+   *
+   * @return JSON representation of an instance of this class.
+   */
+  public JsonObject toJsonObject() {
+    JsonObject extendedThreadInfoJsonObject = new JsonObject();
+    ThreadInfo threadInfo = getThreadInfo();
+    extendedThreadInfoJsonObject.addProperty("name", threadInfo.getThreadName());
+    extendedThreadInfoJsonObject.addProperty("id", threadInfo.getThreadId());
+    extendedThreadInfoJsonObject.addProperty("state", threadInfo.getThreadState().toString());
+    extendedThreadInfoJsonObject.addProperty("priority", threadInfo.getPriority());
+    extendedThreadInfoJsonObject.addProperty("blockedCount", threadInfo.getBlockedCount());
+    extendedThreadInfoJsonObject
+        .addProperty("blockedTimeInMilliSeconds", threadInfo.getBlockedTime());
+    extendedThreadInfoJsonObject.addProperty("lockName", threadInfo.getLockName());
+    extendedThreadInfoJsonObject.addProperty("lockOwnerId", threadInfo.getLockOwnerId());
+    extendedThreadInfoJsonObject.addProperty("lockOwnerName", threadInfo.getLockOwnerName());
+    extendedThreadInfoJsonObject.addProperty("waitedCount", threadInfo.getWaitedCount());
+    extendedThreadInfoJsonObject
+        .addProperty("waitedTimeInMilliSeconds", threadInfo.getWaitedTime());
+    extendedThreadInfoJsonObject.addProperty("isDaemon", threadInfo.isDaemon());
+    extendedThreadInfoJsonObject.addProperty("isInNative", threadInfo.isInNative());
+    extendedThreadInfoJsonObject.addProperty("isSuspended", threadInfo.isSuspended());
+    JsonArray stackTrace = new JsonArray();
+    Arrays.stream(threadInfo.getStackTrace())
+        .map(StackTraceElement::toString)
+        .forEach(stackTrace::add);
+    extendedThreadInfoJsonObject.add("stackTrace", stackTrace);
+
+    return extendedThreadInfoJsonObject;
   }
 }

--- a/src/main/resources/org/padaiyal/utilities/vaidhiyar/JvmUtility_en_US.properties
+++ b/src/main/resources/org/padaiyal/utilities/vaidhiyar/JvmUtility_en_US.properties
@@ -10,3 +10,5 @@ JvmUtility.generateHeapDump.destinationDirectoryDoesNotExist=destinationDirector
 JvmUtility.generateHeapDump.invalidDestinationDirectory=destinationDirectory (%s) has to be a directory.
 JvmUtility.generateHeapDump.generating=Generating heap dump file.
 JvmUtility.generateHeapDump.generated=Generated heap dump at {}
+JvmUtility.error.destinationPathDoesNotExist=destinationDirectory (%s) path does not exist.
+JvmUtility.error.destinationPathNotADirectory=destinationDirectory (%s) path is not a directory.


### PR DESCRIPTION
## Description
Closes #4.
All JVM related information provided by JVMUtility can
now be exported to a JSON file.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [x] **All classes have documentation comments.**
- [x] **All methods have documentation comments.**
- [x] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why.
- [x] **All information to be logged/displayed to the user are internationalized.** If not, explain why. 
- [x] **README.md has been updated if needed.**
- [x] **pom.xml version is set to the latest date** If not, explain why.

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**
- [x] **pom.xml version is set to the latest date** If not, explain why.